### PR TITLE
Explicitly disable unsafe_op_in_unsafe_fn lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [nightly, beta, stable, 1.51.0]
+        rust: [nightly, beta, stable, 1.52.0]
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = ["performance.png", "chart/**"]
 keywords = ["float"]
 license = "Apache-2.0 WITH LLVM-exception OR BSL-1.0"
 repository = "https://github.com/dtolnay/dragonbox"
-rust-version = "1.51"
+rust-version = "1.52"
 
 [dev-dependencies]
 rand = "0.8"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,7 @@
 
 #![no_std]
 #![doc(html_root_url = "https://docs.rs/dragonbox/0.1.7")]
+#![allow(unsafe_op_in_unsafe_fn)]
 #![allow(
     clippy::bool_to_int_with_if,
     clippy::cast_lossless,


### PR DESCRIPTION
This is allow-by-default for now in 2021 edition, but will become warn-by-default in 2024 edition. The lint is not going to provide value in this crate so we'll plan to keep it turned off even after adopting 2024 edition.